### PR TITLE
Add employee filter and badge to account views

### DIFF
--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -16,6 +16,7 @@ type AccountCardProps = {
   pictureUrl: string;
   totalPaid: number;
   totalPurchased: number;
+  isEmployee: boolean;
   onChargeSuccess?: () => void;
 };
 
@@ -48,6 +49,7 @@ export const AccountCard = memo(function AccountCard({
   pictureUrl,
   totalPaid,
   totalPurchased,
+  isEmployee,
   onChargeSuccess,
 }: AccountCardProps) {
   const {isOpen, onOpen, onClose} = useDisclosure();
@@ -114,6 +116,7 @@ export const AccountCard = memo(function AccountCard({
         name={name}
         totalPaid={totalPaid}
         totalPurchased={totalPurchased}
+        isEmployee={isEmployee}
       />
     </>
   );

--- a/src/components/AccountCard.unit.test.tsx
+++ b/src/components/AccountCard.unit.test.tsx
@@ -24,6 +24,7 @@ describe('AccountCard component', () => {
         pictureUrl={pictureUrl}
         totalPaid={totalPaid}
         totalPurchased={totalPurchased}
+        isEmployee={false}
       />,
     );
 
@@ -41,6 +42,7 @@ describe('AccountCard component', () => {
         pictureUrl={pictureUrl}
         totalPaid={totalPaid}
         totalPurchased={totalPurchased}
+        isEmployee={false}
       />,
     );
 
@@ -57,6 +59,7 @@ describe('AccountCard component', () => {
         pictureUrl={pictureUrl}
         totalPaid={30}
         totalPurchased={10}
+        isEmployee={false}
       />,
     );
 
@@ -74,6 +77,7 @@ describe('AccountCard component', () => {
         pictureUrl={pictureUrl}
         totalPaid={10}
         totalPurchased={30}
+        isEmployee={false}
       />,
     );
 
@@ -91,6 +95,7 @@ describe('AccountCard component', () => {
         pictureUrl={pictureUrl}
         totalPaid={20}
         totalPurchased={20}
+        isEmployee={false}
       />,
     );
 
@@ -108,6 +113,7 @@ describe('AccountCard component', () => {
         pictureUrl={pictureUrl}
         totalPaid={50.5}
         totalPurchased={25.25}
+        isEmployee={false}
       />,
     );
 
@@ -120,6 +126,7 @@ describe('AccountCard component', () => {
         pictureUrl={pictureUrl}
         totalPaid={10}
         totalPurchased={35.75}
+        isEmployee={false}
       />,
     );
 

--- a/src/components/AccountDrawer.tsx
+++ b/src/components/AccountDrawer.tsx
@@ -1,5 +1,6 @@
 import {useState, useCallback, useEffect, useRef} from 'react';
 import {
+  Badge,
   Box,
   Drawer,
   DrawerHeader,
@@ -13,6 +14,7 @@ import {
   TabPanels,
   TabPanel,
   Heading,
+  HStack,
   VStack,
   Text,
   SimpleGrid,
@@ -54,6 +56,7 @@ export type AccountDrawerProps = {
   name: string;
   totalPaid: number;
   totalPurchased: number;
+  isEmployee: boolean;
 };
 
 export const AccountDrawer = ({
@@ -64,6 +67,7 @@ export const AccountDrawer = ({
   name,
   totalPaid,
   totalPurchased,
+  isEmployee,
 }: AccountDrawerProps) => {
   const focusableElementRef = useFocusableElementRef();
   const balance = totalPaid - totalPurchased;
@@ -386,7 +390,19 @@ export const AccountDrawer = ({
           borderColor={'gray.200'}
         >
           <VStack align={'start'} spacing={4}>
-            <Heading size={'lg'}>{name}</Heading>
+            <HStack spacing={3}>
+              <Heading size={'lg'}>{name}</Heading>
+              <Badge
+                fontSize={'sm'}
+                fontWeight={'medium'}
+                colorScheme={isEmployee ? 'purple' : 'gray'}
+                px={2}
+                py={1}
+                borderRadius={'md'}
+              >
+                {isEmployee ? 'Employee' : 'Non-Employee'}
+              </Badge>
+            </HStack>
             <Box display={'flex'} gap={3} flexWrap={'wrap'}>
               <Text
                 fontSize={'lg'}

--- a/src/components/AccountDrawer.unit.test.tsx
+++ b/src/components/AccountDrawer.unit.test.tsx
@@ -57,6 +57,7 @@ describe('AccountDrawer component', () => {
         name={name}
         totalPaid={totalPaid}
         totalPurchased={totalPurchased}
+        isEmployee={false}
         onClose={vi.fn()}
       />,
     );
@@ -72,6 +73,7 @@ describe('AccountDrawer component', () => {
         name={name}
         totalPaid={totalPaid}
         totalPurchased={totalPurchased}
+        isEmployee={false}
         onClose={vi.fn()}
       />,
     );
@@ -89,6 +91,7 @@ describe('AccountDrawer component', () => {
         name={name}
         totalPaid={totalPaid}
         totalPurchased={totalPurchased}
+        isEmployee={false}
         onClose={vi.fn()}
       />,
     );
@@ -122,6 +125,7 @@ describe('AccountDrawer component', () => {
         name={name}
         totalPaid={30}
         totalPurchased={10}
+        isEmployee={false}
         onClose={vi.fn()}
       />,
     );
@@ -143,6 +147,7 @@ describe('AccountDrawer component', () => {
           name={name}
           totalPaid={10}
           totalPurchased={30}
+          isEmployee={false}
           onClose={vi.fn()}
         />
       </FocusableElementRefContext.Provider>,
@@ -165,6 +170,7 @@ describe('AccountDrawer component', () => {
         name={name}
         totalPaid={totalPaid}
         totalPurchased={totalPurchased}
+        isEmployee={false}
         onClose={vi.fn()}
       />,
     );

--- a/src/pages/AccountGrid.unit.test.tsx
+++ b/src/pages/AccountGrid.unit.test.tsx
@@ -127,11 +127,10 @@ describe('AccountGrid sorting', () => {
     vi.mocked(useAccounts).mockReturnValue(mockAccounts);
     const user = userEvent.setup();
 
-    const {getAllByTestId, getByRole, findByRole} = renderAccountGrid();
+    const {getAllByTestId, getByRole} = renderAccountGrid();
 
-    // Open sort menu and select "Debt"
-    await user.click(getByRole('button', {name: 'Last Transaction'}));
-    await user.click(await findByRole('menuitem', {name: 'Debt'}));
+    // Click "Debt" button
+    await user.click(getByRole('button', {name: 'Debt'}));
 
     const cards = getAllByTestId(/^account-card-/);
 
@@ -146,11 +145,10 @@ describe('AccountGrid sorting', () => {
     vi.mocked(useAccounts).mockReturnValue(mockAccounts);
     const user = userEvent.setup();
 
-    const {getAllByTestId, getByRole, findByRole} = renderAccountGrid();
+    const {getAllByTestId, getByRole} = renderAccountGrid();
 
-    // Open sort menu and select "Total Paid"
-    await user.click(getByRole('button', {name: 'Last Transaction'}));
-    await user.click(await findByRole('menuitem', {name: 'Total Paid'}));
+    // Click "Total Paid" button
+    await user.click(getByRole('button', {name: 'Total Paid'}));
 
     const cards = getAllByTestId(/^account-card-/);
 


### PR DESCRIPTION
## Summary
- Add employee/non-employee filter buttons to AccountGrid for filtering accounts by employee status
- Display employee status badge (purple for Employee, gray for Non-Employee) in AccountDrawer header
- Replace sort dropdown menu with button group UI for consistency with new filter controls
- Thread `isEmployee` prop through AccountCard to AccountDrawer components

## Test plan
- [x] Build passes (`yarn build`)
- [x] All unit tests pass (`yarn test:unit` - 109 tests)
- [x] All integration tests pass (`yarn test:integration` - 21 tests)
- [x] Linting passes (`yarn lint`)
- [x] Formatting passes (`yarn prettier`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)