### PR TITLE
Add setup script and firebase wrapper for multi-agent development

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -15,6 +15,11 @@ jobs:
           cache: yarn
           cache-dependency-path: yarn.lock
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
       - name: Install firebase-tools
         run: yarn global add firebase-tools
 

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -18,6 +18,11 @@ jobs:
           cache: yarn
           cache-dependency-path: yarn.lock
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
       - name: Install firebase-tools
         run: yarn global add firebase-tools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,12 +160,14 @@ For operations that modify multiple documents (e.g., recording a purchase update
 
 ### Firebase Emulators
 
-**Emulator Ports:**
+**Emulator Ports (defaults):**
 
 - Firestore: 8080
 - Auth: 9099
 - Functions: 5001
 - UI: 4000 (http://localhost:4000)
+
+Emulator ports can be customized via `VITE_FIRESTORE_PORT`, `VITE_AUTH_PORT`, and `VITE_FUNCTIONS_PORT` env vars (falling back to the defaults above).
 
 **Emulator Data Persistence:**
 

--- a/bin/firebase-wrapper.js
+++ b/bin/firebase-wrapper.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import {readFileSync, writeFileSync, unlinkSync, existsSync} from 'fs';
+import {join, dirname} from 'path';
+import {fileURLToPath} from 'url';
+import {tmpdir} from 'os';
+import {randomBytes} from 'crypto';
+import {execFileSync} from 'child_process';
+
+const DEFAULT_FIRESTORE_PORT = 8080;
+const DEFAULT_AUTH_PORT = 9099;
+const DEFAULT_FUNCTIONS_PORT = 5001;
+const DEFAULT_UI_PORT = 4000;
+
+const projectDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const envFiles = ['.env', '.env.local'];
+for (const envFile of envFiles) {
+  const envPath = join(projectDir, envFile);
+  if (existsSync(envPath)) {
+    for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+      const match = line.match(/^(\w+)=(.*)$/);
+      if (match && !process.env[match[1]]) {
+        process.env[match[1]] = match[2];
+      }
+    }
+  }
+}
+
+const baseConfigPath = join(projectDir, 'firebase.json');
+
+const config = JSON.parse(readFileSync(baseConfigPath, 'utf8'));
+
+config.emulators = config.emulators || {};
+config.emulators.auth = {
+  ...config.emulators.auth,
+  port: Number(process.env.VITE_AUTH_PORT || DEFAULT_AUTH_PORT),
+};
+config.emulators.firestore = {
+  ...config.emulators.firestore,
+  port: Number(process.env.VITE_FIRESTORE_PORT || DEFAULT_FIRESTORE_PORT),
+};
+config.emulators.functions = {
+  ...config.emulators.functions,
+  port: Number(process.env.VITE_FUNCTIONS_PORT || DEFAULT_FUNCTIONS_PORT),
+};
+config.emulators.ui = {
+  ...config.emulators.ui,
+  port: Number(process.env.VITE_UI_PORT || DEFAULT_UI_PORT),
+};
+
+const tempConfig = join(
+  tmpdir(),
+  `firebase-${randomBytes(6).toString('hex')}.json`,
+);
+writeFileSync(tempConfig, JSON.stringify(config, null, 2));
+
+const args = ['--config', tempConfig, ...process.argv.slice(2)];
+
+try {
+  execFileSync('firebase', args, {stdio: 'inherit'});
+} finally {
+  try {
+    unlinkSync(tempConfig);
+  } catch {}
+}

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PORT_OFFSET=0
+FIRESTORE_PORT_OFFSET=1
+AUTH_PORT_OFFSET=2
+FUNCTIONS_PORT_OFFSET=3
+UI_PORT_OFFSET=4
+
+BASE_PORT="${1:-}"
+
+if [ -z "$BASE_PORT" ] || ! [[ "$BASE_PORT" =~ ^[0-9]+$ ]]; then
+  echo "Usage: bin/setup.sh <base-port>" >&2
+  echo "Example: bin/setup.sh 9000" >&2
+  echo "" >&2
+  echo "This will assign:" >&2
+  echo "  App:        <base-port>" >&2
+  echo "  Firestore:  <base-port> + 1" >&2
+  echo "  Auth:       <base-port> + 2" >&2
+  echo "  Functions:  <base-port> + 3" >&2
+  echo "  UI:         <base-port> + 4" >&2
+  exit 1
+fi
+
+export VITE_APP_PORT=$((BASE_PORT + APP_PORT_OFFSET))
+export VITE_FIRESTORE_PORT=$((BASE_PORT + FIRESTORE_PORT_OFFSET))
+export VITE_AUTH_PORT=$((BASE_PORT + AUTH_PORT_OFFSET))
+export VITE_FUNCTIONS_PORT=$((BASE_PORT + FUNCTIONS_PORT_OFFSET))
+export VITE_UI_PORT=$((BASE_PORT + UI_PORT_OFFSET))
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$PROJECT_DIR/.env.local"
+
+echo "Setting up with base port $BASE_PORT:"
+echo "  App:        $VITE_APP_PORT"
+echo "  Firestore:  $VITE_FIRESTORE_PORT"
+echo "  Auth:       $VITE_AUTH_PORT"
+echo "  Functions:  $VITE_FUNCTIONS_PORT"
+echo "  UI:         $VITE_UI_PORT"
+echo ""
+
+cat > "$ENV_FILE" <<EOF
+VITE_APP_PORT=$VITE_APP_PORT
+VITE_FIRESTORE_PORT=$VITE_FIRESTORE_PORT
+VITE_AUTH_PORT=$VITE_AUTH_PORT
+VITE_FUNCTIONS_PORT=$VITE_FUNCTIONS_PORT
+VITE_UI_PORT=$VITE_UI_PORT
+EOF
+echo "Port config written to .env.local"
+echo ""
+
+echo "> yarn install"
+yarn --cwd "$PROJECT_DIR" install
+echo ""
+
+echo "> yarn install (functions)"
+yarn --cwd "$PROJECT_DIR/functions" install
+echo ""
+
+echo "> yarn fixtures"
+yarn --cwd "$PROJECT_DIR" fixtures

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774386573,
+        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "Chaas development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        myNode = pkgs.nodejs_22;
+        myYarn = pkgs.yarn.override { nodejs = myNode; };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [
+            myNode
+            myYarn
+            pkgs.jdk21_headless
+            pkgs.firebase-tools
+            pkgs.jq
+          ];
+
+          shellHook = ''
+            echo "Chaas dev environment loaded"
+            echo "  Node:     $(node --version)"
+            echo "  Yarn:     $(yarn --version)"
+            echo "  Java:     $(java --version 2>&1 | head -1)"
+            echo "  Firebase: $(firebase --version)"
+            echo ""
+            echo "Commands:"
+            echo "  yarn dev            — Start dev server + emulators"
+            echo "  yarn fixtures       — Load test data"
+            echo "  yarn test:unit      — Run unit tests"
+            echo "  yarn test:integration — Run integration tests"
+          '';
+        };
+      }
+    );
+}

--- a/functions/src/scripts/update-users.ts
+++ b/functions/src/scripts/update-users.ts
@@ -22,8 +22,9 @@ const app = initializeApp({
 const firestore = getFirestore(app);
 
 // Connect to emulators
+const firestorePort = process.env.VITE_FIRESTORE_PORT ?? '8080';
 firestore.settings({
-  host: 'localhost:8080',
+  host: `localhost:${firestorePort}`,
   ssl: false,
 });
 

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "prod": "vite",
     "build": "tsc -b && vite build",
     "build-functions": "cd functions && yarn build --watch",
-    "emulators": "firebase emulators:start --project chaas-dev --only firestore,auth,functions --import .emulators --export-on-exit .emulators",
-    "fixtures": "firebase emulators:exec --project chaas-dev --only firestore,auth --import .emulators --export-on-exit .emulators 'vite-node bin/fixtures.ts'",
-    "fixtures:preprod": "firebase emulators:exec --project chaas-dev --only firestore,auth --import .emulators --export-on-exit .emulators 'vite-node bin/fixtures-prod.ts'",
+    "emulators": "bin/firebase-wrapper.js emulators:start --project chaas-dev --only firestore,auth,functions --import .emulators --export-on-exit .emulators",
+    "fixtures": "bin/firebase-wrapper.js emulators:exec --project chaas-dev --only firestore,auth --import .emulators --export-on-exit .emulators 'vite-node bin/fixtures.ts'",
+    "fixtures:preprod": "bin/firebase-wrapper.js emulators:exec --project chaas-dev --only firestore,auth --import .emulators --export-on-exit .emulators 'vite-node bin/fixtures-prod.ts'",
     "fixtures:prod": "vite-node bin/fixtures-prod.ts",
     "convert-fixtures": "vite-node bin/convert-export-to-fixtures.ts",
-    "update-users": "firebase emulators:exec --project chaas-dev --only firestore,auth --import .emulators --export-on-exit .emulators 'node functions/lib/scripts/update-users.js'",
+    "update-users": "bin/firebase-wrapper.js emulators:exec --project chaas-dev --only firestore,auth --import .emulators --export-on-exit .emulators 'node functions/lib/scripts/update-users.js'",
     "update-users:prod": "node functions/lib/scripts/update-users.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -22,8 +22,8 @@
     "preview": "vite preview",
     "test:unit": "vitest run --project unit --project unit-node",
     "test:unit:watch": "vitest watch --project unit --project unit-node",
-    "test:integration": "firebase emulators:exec --project chaas-test --only firestore,auth 'vitest run --project integration'",
-    "test:integration:watch": "firebase emulators:exec --project chaas-test --only firestore,auth 'vitest watch --project integration'"
+    "test:integration": "bin/firebase-wrapper.js emulators:exec --project chaas-test --only firestore,auth 'vitest run --project integration'",
+    "test:integration:watch": "bin/firebase-wrapper.js emulators:exec --project chaas-test --only firestore,auth 'vitest watch --project integration'"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.2.4",

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -38,12 +38,18 @@ export const createFirebaseApp = (env: Env): FirebaseApp => {
   const app = initializeApp(options);
 
   if (env !== Env.PROD) {
+    const firestorePort = Number(import.meta.env.VITE_FIRESTORE_PORT || 8080);
+    const authPort = Number(import.meta.env.VITE_AUTH_PORT || 9099);
+    const functionsPort = Number(import.meta.env.VITE_FUNCTIONS_PORT || 5001);
+
     const firestore = getFirestore(app);
-    connectFirestoreEmulator(firestore, 'localhost', 8080);
+    connectFirestoreEmulator(firestore, 'localhost', firestorePort);
     const auth = getAuth(app);
-    connectAuthEmulator(auth, 'http://localhost:9099', {disableWarnings: true});
+    connectAuthEmulator(auth, `http://localhost:${String(authPort)}`, {
+      disableWarnings: true,
+    });
     const functions = getFunctions(app);
-    connectFunctionsEmulator(functions, 'localhost', 5001);
+    connectFunctionsEmulator(functions, 'localhost', functionsPort);
   }
 
   return app;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,26 @@
-import {defineConfig} from 'vite';
+import {defineConfig, loadEnv} from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import {viteStaticCopy} from 'vite-plugin-static-copy';
 
-export default defineConfig({
-  plugins: [
-    react(),
-    viteStaticCopy({
-      targets: [
-        {
-          src: 'src/assets/*',
-          dest: 'assets',
-        },
-      ],
-    }),
-  ],
+export default defineConfig(({mode}) => {
+  const env = loadEnv(mode, process.cwd());
+  const appPort = Number(env.VITE_APP_PORT || 5173);
+
+  return {
+    server: {
+      port: appPort,
+      strictPort: true,
+    },
+    plugins: [
+      react(),
+      viteStaticCopy({
+        targets: [
+          {
+            src: 'src/assets/*',
+            dest: 'assets',
+          },
+        ],
+      }),
+    ],
+  };
 });


### PR DESCRIPTION
## Summary
- Add `bin/setup.sh` script that takes a base port and derives all service ports (app, Firestore, Auth, Functions, UI) with sequential offsets
- Add `bin/firebase-wrapper.js` that generates a temporary `firebase.json` with port-overridden emulator config, loading from `.env` and `.env.local`
- Make Vite dev server port configurable via `VITE_APP_PORT`
- Replace all direct `firebase` CLI calls in `package.json` with the wrapper
- Fix hardcoded Firestore port in `functions/src/scripts/update-users.ts`
- Add Nix flake for reproducible dev environment

## Test plan
- [x] Run `bin/setup.sh 9000` and verify `.env.local` is created with correct ports
- [x] Run `yarn dev` and verify all emulators and Vite start on the configured ports
- [x] Run two instances with different base ports in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)