### PR TITLE
Add automated Slack debt reminders (dry-run only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ dist-ssr
 # Firebase
 .firebaserc
 .firebase
+.firebase-config.json
 .emulators
 
 # prod fixtures

--- a/bin/firebase-wrapper.js
+++ b/bin/firebase-wrapper.js
@@ -3,8 +3,6 @@
 import {readFileSync, writeFileSync, unlinkSync, existsSync} from 'fs';
 import {join, dirname} from 'path';
 import {fileURLToPath} from 'url';
-import {tmpdir} from 'os';
-import {randomBytes} from 'crypto';
 import {execFileSync} from 'child_process';
 
 const DEFAULT_FIRESTORE_PORT = 8080;
@@ -49,10 +47,7 @@ config.emulators.ui = {
   port: Number(process.env.VITE_UI_PORT || DEFAULT_UI_PORT),
 };
 
-const tempConfig = join(
-  tmpdir(),
-  `firebase-${randomBytes(6).toString('hex')}.json`,
-);
+const tempConfig = join(projectDir, '.firebase-config.json');
 writeFileSync(tempConfig, JSON.stringify(config, null, 2));
 
 const args = ['--config', tempConfig, ...process.argv.slice(2)];

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,3 +8,4 @@ export {updateUsers} from './updateUsers.js';
 export {sendPaymentLink} from './sendPaymentLink.js';
 export {handleSumUpWebhook} from './handleSumUpWebhook.js';
 export {getPaymentLinkForSlackUser} from './getPaymentLinkForSlackUser.js';
+export {sendDebtRemindersDryRun} from './sendDebtReminders.js';

--- a/functions/src/sendDebtReminders.ts
+++ b/functions/src/sendDebtReminders.ts
@@ -1,0 +1,29 @@
+import {onCall, HttpsError} from 'firebase-functions/v2/https';
+import {getFirestore} from 'firebase-admin/firestore';
+import {executeDebtReminders} from './shared/debtReminderService.js';
+
+export const sendDebtRemindersDryRun = onCall(async (request) => {
+  if (!request.auth) {
+    throw new HttpsError('unauthenticated', 'Must be logged in');
+  }
+
+  try {
+    const results = await executeDebtReminders({
+      firestore: getFirestore(),
+      dryRun: true,
+    });
+
+    return results;
+  } catch (error) {
+    console.error('Error executing debt reminders dry run:', error);
+
+    if (error instanceof Error) {
+      throw new HttpsError(
+        'internal',
+        `Failed to run debt reminders: ${error.message}`,
+      );
+    }
+
+    throw new HttpsError('internal', 'An unknown error occurred');
+  }
+});

--- a/functions/src/sendDebtReminders.unit.test.ts
+++ b/functions/src/sendDebtReminders.unit.test.ts
@@ -1,5 +1,4 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {HttpsError} from 'firebase-functions/v2/https';
 
 const mockExecuteDebtReminders = vi.fn();
 
@@ -12,16 +11,21 @@ vi.mock('./shared/debtReminderService.js', () => ({
     mockExecuteDebtReminders(...args),
 }));
 
-vi.mock('firebase-functions/v2/https', async () => {
-  const actual = await vi.importActual<
-    typeof import('firebase-functions/v2/https')
-  >('firebase-functions/v2/https');
+vi.mock('firebase-functions/v2/https', () => {
+  class HttpsError extends Error {
+    code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.code = code;
+    }
+  }
   return {
-    ...actual,
+    HttpsError,
     onCall: (handler: (request: unknown) => unknown) => handler,
   };
 });
 
+import {HttpsError} from 'firebase-functions/v2/https';
 import {sendDebtRemindersDryRun} from './sendDebtReminders';
 
 describe('sendDebtRemindersDryRun', () => {

--- a/functions/src/sendDebtReminders.unit.test.ts
+++ b/functions/src/sendDebtReminders.unit.test.ts
@@ -28,6 +28,9 @@ vi.mock('firebase-functions/v2/https', () => {
 import {HttpsError} from 'firebase-functions/v2/https';
 import {sendDebtRemindersDryRun} from './sendDebtReminders';
 
+type CallableHandler = (request: unknown) => Promise<unknown>;
+const handler = sendDebtRemindersDryRun as unknown as CallableHandler;
+
 describe('sendDebtRemindersDryRun', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,11 +39,7 @@ describe('sendDebtRemindersDryRun', () => {
   it('throws unauthenticated error when not logged in', async () => {
     const request = {auth: null};
 
-    await expect(
-      (sendDebtRemindersDryRun as (req: typeof request) => Promise<unknown>)(
-        request,
-      ),
-    ).rejects.toThrow(HttpsError);
+    await expect(handler(request)).rejects.toThrow(HttpsError);
   });
 
   it('calls executeDebtReminders with dryRun true', async () => {
@@ -53,9 +52,7 @@ describe('sendDebtRemindersDryRun', () => {
     mockExecuteDebtReminders.mockResolvedValue(mockResults);
 
     const request = {auth: {uid: 'user-1'}};
-    const result = await (
-      sendDebtRemindersDryRun as (req: typeof request) => Promise<unknown>
-    )(request);
+    const result = await handler(request);
 
     expect(result).toEqual(mockResults);
     expect(mockExecuteDebtReminders).toHaveBeenCalledWith({
@@ -71,10 +68,6 @@ describe('sendDebtRemindersDryRun', () => {
 
     const request = {auth: {uid: 'user-1'}};
 
-    await expect(
-      (sendDebtRemindersDryRun as (req: typeof request) => Promise<unknown>)(
-        request,
-      ),
-    ).rejects.toThrow(HttpsError);
+    await expect(handler(request)).rejects.toThrow(HttpsError);
   });
 });

--- a/functions/src/sendDebtReminders.unit.test.ts
+++ b/functions/src/sendDebtReminders.unit.test.ts
@@ -1,0 +1,76 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {HttpsError} from 'firebase-functions/v2/https';
+
+const mockExecuteDebtReminders = vi.fn();
+
+vi.mock('firebase-admin/firestore', () => ({
+  getFirestore: vi.fn(() => 'mock-firestore'),
+}));
+
+vi.mock('./shared/debtReminderService.js', () => ({
+  executeDebtReminders: (...args: unknown[]) =>
+    mockExecuteDebtReminders(...args),
+}));
+
+vi.mock('firebase-functions/v2/https', async () => {
+  const actual = await vi.importActual<
+    typeof import('firebase-functions/v2/https')
+  >('firebase-functions/v2/https');
+  return {
+    ...actual,
+    onCall: (handler: (request: unknown) => unknown) => handler,
+  };
+});
+
+import {sendDebtRemindersDryRun} from './sendDebtReminders';
+
+describe('sendDebtRemindersDryRun', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws unauthenticated error when not logged in', async () => {
+    const request = {auth: null};
+
+    await expect(
+      (sendDebtRemindersDryRun as (req: typeof request) => Promise<unknown>)(
+        request,
+      ),
+    ).rejects.toThrow(HttpsError);
+  });
+
+  it('calls executeDebtReminders with dryRun true', async () => {
+    const mockResults = {
+      summary: {high: 1, medium: 0, low: 0, total: 1, sent: 0, failed: 0},
+      details: [],
+      dryRun: true,
+      executedAt: '2026-04-01T00:00:00.000Z',
+    };
+    mockExecuteDebtReminders.mockResolvedValue(mockResults);
+
+    const request = {auth: {uid: 'user-1'}};
+    const result = await (
+      sendDebtRemindersDryRun as (req: typeof request) => Promise<unknown>
+    )(request);
+
+    expect(result).toEqual(mockResults);
+    expect(mockExecuteDebtReminders).toHaveBeenCalledWith({
+      firestore: 'mock-firestore',
+      dryRun: true,
+    });
+  });
+
+  it('throws internal error when executeDebtReminders fails', async () => {
+    mockExecuteDebtReminders.mockRejectedValue(
+      new Error('Firestore unavailable'),
+    );
+
+    const request = {auth: {uid: 'user-1'}};
+
+    await expect(
+      (sendDebtRemindersDryRun as (req: typeof request) => Promise<unknown>)(
+        request,
+      ),
+    ).rejects.toThrow(HttpsError);
+  });
+});

--- a/functions/src/shared/debtReminderService.ts
+++ b/functions/src/shared/debtReminderService.ts
@@ -52,6 +52,8 @@ export const categorizeAccounts = (
     }
   }
 
+  results.sort((a, b) => b.debt - a.debt);
+
   return results;
 };
 
@@ -60,6 +62,7 @@ export interface ReminderResult {
   slackId: string;
   debt: number;
   tier: ReminderTier;
+  lastPurchaseTimestamp: number;
   sent: boolean;
   error?: string;
 }
@@ -115,6 +118,7 @@ export const executeDebtReminders = async (
       slackId: entry.account.slack.id,
       debt: entry.debt,
       tier: entry.tier,
+      lastPurchaseTimestamp: entry.account.activity.lastPurchaseTimestamp,
       sent: false,
     }));
     return results;
@@ -132,6 +136,7 @@ export const executeDebtReminders = async (
       slackId: entry.account.slack.id,
       debt: entry.debt,
       tier: entry.tier,
+      lastPurchaseTimestamp: entry.account.activity.lastPurchaseTimestamp,
       sent: false,
     };
 

--- a/functions/src/shared/debtReminderService.ts
+++ b/functions/src/shared/debtReminderService.ts
@@ -1,0 +1,179 @@
+import {WebClient} from '@slack/web-api';
+import type {Firestore} from 'firebase-admin/firestore';
+import type {Account} from './updateUsersLogic.js';
+
+const HIGH_DEBT_THRESHOLD = 10;
+const MEDIUM_DEBT_THRESHOLD = 5;
+const DAYS_INACTIVE_FOR_MEDIUM_DEBT = 30;
+const MONTHS_INACTIVE_FOR_LOW_DEBT = 6;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type ReminderTier = 'high' | 'medium' | 'low';
+
+export interface AccountWithDebt {
+  account: Account;
+  debt: number;
+  tier: ReminderTier;
+}
+
+const getDebt = (account: Account): number =>
+  account.activity.totalPurchased - account.activity.totalPaid;
+
+const daysSince = (timestamp: number, now: number): number =>
+  (now - timestamp) / MS_PER_DAY;
+
+export const categorizeAccounts = (
+  accounts: Account[],
+  now: number,
+): AccountWithDebt[] => {
+  const results: AccountWithDebt[] = [];
+
+  for (const account of accounts) {
+    if (!account.isEmployee) continue;
+
+    const debt = getDebt(account);
+    if (debt <= 0) continue;
+
+    const lastPurchase = account.activity.lastPurchaseTimestamp;
+    const inactiveDays = daysSince(lastPurchase, now);
+
+    if (debt > HIGH_DEBT_THRESHOLD) {
+      results.push({account, debt, tier: 'high'});
+    } else if (
+      debt > MEDIUM_DEBT_THRESHOLD &&
+      inactiveDays >= DAYS_INACTIVE_FOR_MEDIUM_DEBT
+    ) {
+      results.push({account, debt, tier: 'medium'});
+    } else if (
+      debt <= MEDIUM_DEBT_THRESHOLD &&
+      inactiveDays >= MONTHS_INACTIVE_FOR_LOW_DEBT * 30
+    ) {
+      results.push({account, debt, tier: 'low'});
+    }
+  }
+
+  return results;
+};
+
+export interface ReminderResult {
+  name: string;
+  slackId: string;
+  debt: number;
+  tier: ReminderTier;
+  sent: boolean;
+  error?: string;
+}
+
+export interface DebtRemindersResults {
+  summary: {
+    high: number;
+    medium: number;
+    low: number;
+    total: number;
+    sent: number;
+    failed: number;
+  };
+  details: ReminderResult[];
+  dryRun: boolean;
+  executedAt: string;
+}
+
+export interface DebtRemindersOptions {
+  firestore: Firestore;
+  slackBotToken?: string;
+  dryRun?: boolean;
+}
+
+export const executeDebtReminders = async (
+  options: DebtRemindersOptions,
+): Promise<DebtRemindersResults> => {
+  const {slackBotToken, firestore, dryRun = false} = options;
+
+  const snapshot = await firestore.collection('accounts').get();
+  const accounts = snapshot.docs.map((doc) => doc.data() as Account);
+
+  const now = Date.now();
+  const reminders = categorizeAccounts(accounts, now);
+
+  const results: DebtRemindersResults = {
+    summary: {
+      high: reminders.filter((r) => r.tier === 'high').length,
+      medium: reminders.filter((r) => r.tier === 'medium').length,
+      low: reminders.filter((r) => r.tier === 'low').length,
+      total: reminders.length,
+      sent: 0,
+      failed: 0,
+    },
+    details: [],
+    dryRun,
+    executedAt: new Date().toISOString(),
+  };
+
+  if (dryRun) {
+    results.details = reminders.map((entry) => ({
+      name: entry.account.slack.name,
+      slackId: entry.account.slack.id,
+      debt: entry.debt,
+      tier: entry.tier,
+      sent: false,
+    }));
+    return results;
+  }
+
+  if (!slackBotToken) {
+    throw new Error('slackBotToken is required when dryRun is false');
+  }
+
+  const slackClient = new WebClient(slackBotToken);
+
+  for (const entry of reminders) {
+    const result: ReminderResult = {
+      name: entry.account.slack.name,
+      slackId: entry.account.slack.id,
+      debt: entry.debt,
+      tier: entry.tier,
+      sent: false,
+    };
+
+    try {
+      await slackClient.chat.postMessage({
+        channel: entry.account.slack.id,
+        text: buildReminderMessage(entry),
+        unfurl_links: false,
+      });
+      result.sent = true;
+      results.summary.sent++;
+    } catch (error) {
+      result.error = error instanceof Error ? error.message : 'Unknown error';
+      results.summary.failed++;
+    }
+
+    results.details.push(result);
+  }
+
+  return results;
+};
+
+export const buildReminderMessage = (entry: AccountWithDebt): string => {
+  const debtFormatted = entry.debt.toFixed(2);
+
+  switch (entry.tier) {
+    case 'high':
+      return `:chaquip-cat: Hey dear Chaquiper! :chaquip-cat:
+:warning: Your Chaquip tab is at *${debtFormatted}€*.
+That's above our ${String(HIGH_DEBT_THRESHOLD)}€ threshold — could you settle up when you get a chance?
+Bisous :money_with_wings:`;
+
+    case 'medium':
+      return `:chaquip-cat: Hey dear Chaquiper! :chaquip-cat:
+:eyes: We noticed you haven't grabbed anything from the Chaquip in a while, but you still have an open tab of *${debtFormatted}€*.
+Since it's been over ${String(DAYS_INACTIVE_FOR_MEDIUM_DEBT)} days since your last purchase, this is a friendly nudge to settle up!
+Bisous :money_with_wings:`;
+
+    case 'low':
+      return `:chaquip-cat: Hey dear Chaquiper! :chaquip-cat:
+:wave: Long time no see! You still have a small tab of *${debtFormatted}€* on the Chaquip.
+It's been over ${String(MONTHS_INACTIVE_FOR_LOW_DEBT)} months since your last visit — just a gentle reminder to clear it when you can.
+Bisous :money_with_wings:`;
+  }
+};

--- a/functions/src/shared/debtReminderService.unit.test.ts
+++ b/functions/src/shared/debtReminderService.unit.test.ts
@@ -1,0 +1,352 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {
+  categorizeAccounts,
+  buildReminderMessage,
+  executeDebtReminders,
+} from './debtReminderService';
+import type {Account} from './updateUsersLogic';
+
+const mockPostMessage = vi.fn();
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn().mockImplementation(() => ({
+    chat: {
+      postMessage: mockPostMessage,
+    },
+  })),
+}));
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const makeAccount = (
+  overrides: Partial<Account> & {
+    totalPurchased?: number;
+    totalPaid?: number;
+    lastPurchaseTimestamp?: number;
+    isEmployee?: boolean;
+  },
+): Account => ({
+  id: overrides.id ?? 'account-1',
+  slack: {
+    id: 'slack-1',
+    name: 'Test User',
+    username: 'testuser',
+    pictureUrl: 'https://example.com/pic.jpg',
+    ...overrides.slack,
+  },
+  activity: {
+    totalPurchased: overrides.totalPurchased ?? 0,
+    totalPaid: overrides.totalPaid ?? 0,
+    lastPurchaseTimestamp: overrides.lastPurchaseTimestamp ?? 0,
+    lastPaymentTimestamp: 0,
+  },
+  isEmployee: overrides.isEmployee ?? true,
+});
+
+describe('categorizeAccounts', () => {
+  const now = Date.now();
+
+  it('returns high tier for debt above 10€', () => {
+    const accounts = [makeAccount({totalPurchased: 15, totalPaid: 0})];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tier).toBe('high');
+    expect(result[0].debt).toBe(15);
+  });
+
+  it('returns high tier regardless of last purchase date', () => {
+    const accounts = [
+      makeAccount({
+        totalPurchased: 12,
+        totalPaid: 0,
+        lastPurchaseTimestamp: now,
+      }),
+    ];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tier).toBe('high');
+  });
+
+  it('returns medium tier for 5-10€ debt inactive 30+ days', () => {
+    const accounts = [
+      makeAccount({
+        totalPurchased: 8,
+        totalPaid: 0,
+        lastPurchaseTimestamp: now - 31 * MS_PER_DAY,
+      }),
+    ];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tier).toBe('medium');
+    expect(result[0].debt).toBe(8);
+  });
+
+  it('skips medium tier if last purchase was recent', () => {
+    const accounts = [
+      makeAccount({
+        totalPurchased: 8,
+        totalPaid: 0,
+        lastPurchaseTimestamp: now - 10 * MS_PER_DAY,
+      }),
+    ];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns low tier for debt ≤5€ inactive 6+ months', () => {
+    const accounts = [
+      makeAccount({
+        totalPurchased: 3,
+        totalPaid: 0,
+        lastPurchaseTimestamp: now - 181 * MS_PER_DAY,
+      }),
+    ];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tier).toBe('low');
+    expect(result[0].debt).toBe(3);
+  });
+
+  it('skips low tier if last purchase was recent', () => {
+    const accounts = [
+      makeAccount({
+        totalPurchased: 3,
+        totalPaid: 0,
+        lastPurchaseTimestamp: now - 60 * MS_PER_DAY,
+      }),
+    ];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips accounts with no debt', () => {
+    const accounts = [makeAccount({totalPurchased: 5, totalPaid: 5})];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips accounts with negative debt (overpaid)', () => {
+    const accounts = [makeAccount({totalPurchased: 5, totalPaid: 10})];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips non-employee accounts', () => {
+    const accounts = [
+      makeAccount({totalPurchased: 20, totalPaid: 0, isEmployee: false}),
+    ];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('categorizes multiple accounts correctly', () => {
+    const accounts = [
+      makeAccount({
+        id: 'high',
+        totalPurchased: 15,
+        totalPaid: 0,
+        lastPurchaseTimestamp: now,
+      }),
+      makeAccount({
+        id: 'medium',
+        totalPurchased: 7,
+        totalPaid: 0,
+        lastPurchaseTimestamp: now - 35 * MS_PER_DAY,
+      }),
+      makeAccount({
+        id: 'low',
+        totalPurchased: 4,
+        totalPaid: 0,
+        lastPurchaseTimestamp: now - 200 * MS_PER_DAY,
+      }),
+      makeAccount({
+        id: 'no-debt',
+        totalPurchased: 5,
+        totalPaid: 5,
+      }),
+    ];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(3);
+    expect(result.map((r) => r.tier)).toEqual(['high', 'medium', 'low']);
+  });
+
+  it('handles exactly 10€ debt as medium tier (not high)', () => {
+    const accounts = [
+      makeAccount({
+        totalPurchased: 10,
+        totalPaid: 0,
+        lastPurchaseTimestamp: now - 31 * MS_PER_DAY,
+      }),
+    ];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tier).toBe('medium');
+  });
+
+  it('handles exactly 5€ debt as low tier (not medium)', () => {
+    const accounts = [
+      makeAccount({
+        totalPurchased: 5,
+        totalPaid: 0,
+        lastPurchaseTimestamp: now - 200 * MS_PER_DAY,
+      }),
+    ];
+    const result = categorizeAccounts(accounts, now);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tier).toBe('low');
+  });
+});
+
+const createMockFirestore = (accounts: Account[]) =>
+  ({
+    collection: vi.fn().mockReturnValue({
+      get: vi.fn().mockResolvedValue({
+        docs: accounts.map((a) => ({data: () => a})),
+      }),
+    }),
+  }) as any;
+
+describe('executeDebtReminders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPostMessage.mockResolvedValue({ok: true});
+  });
+
+  it('returns details without sending messages in dry run', async () => {
+    const accounts = [makeAccount({totalPurchased: 15, totalPaid: 0})];
+    const firestore = createMockFirestore(accounts);
+
+    const results = await executeDebtReminders({
+      slackBotToken: 'fake-token',
+      firestore,
+      dryRun: true,
+    });
+
+    expect(results.dryRun).toBe(true);
+    expect(results.summary.total).toBe(1);
+    expect(results.summary.sent).toBe(0);
+    expect(results.details).toHaveLength(1);
+    expect(results.details[0].name).toBe('Test User');
+    expect(results.details[0].tier).toBe('high');
+    expect(results.details[0].sent).toBe(false);
+    expect(mockPostMessage).not.toHaveBeenCalled();
+  });
+
+  it('sends messages when not in dry run', async () => {
+    const accounts = [makeAccount({totalPurchased: 15, totalPaid: 0})];
+    const firestore = createMockFirestore(accounts);
+
+    const results = await executeDebtReminders({
+      slackBotToken: 'fake-token',
+      firestore,
+    });
+
+    expect(results.dryRun).toBe(false);
+    expect(results.summary.sent).toBe(1);
+    expect(results.details[0].sent).toBe(true);
+    expect(mockPostMessage).toHaveBeenCalledOnce();
+  });
+
+  it('handles send failures gracefully', async () => {
+    mockPostMessage.mockRejectedValue(new Error('Slack API error'));
+    const accounts = [makeAccount({totalPurchased: 15, totalPaid: 0})];
+    const firestore = createMockFirestore(accounts);
+
+    const results = await executeDebtReminders({
+      slackBotToken: 'fake-token',
+      firestore,
+    });
+
+    expect(results.summary.failed).toBe(1);
+    expect(results.summary.sent).toBe(0);
+    expect(results.details[0].sent).toBe(false);
+    expect(results.details[0].error).toBe('Slack API error');
+  });
+
+  it('dry run includes correct tier breakdown in summary', async () => {
+    const accounts = [
+      makeAccount({
+        id: 'high',
+        totalPurchased: 15,
+        totalPaid: 0,
+        lastPurchaseTimestamp: Date.now(),
+      }),
+      makeAccount({
+        id: 'medium',
+        totalPurchased: 7,
+        totalPaid: 0,
+        lastPurchaseTimestamp: Date.now() - 35 * MS_PER_DAY,
+      }),
+      makeAccount({
+        id: 'no-debt',
+        totalPurchased: 5,
+        totalPaid: 5,
+      }),
+    ];
+    const firestore = createMockFirestore(accounts);
+
+    const results = await executeDebtReminders({
+      slackBotToken: 'fake-token',
+      firestore,
+      dryRun: true,
+    });
+
+    expect(results.summary.high).toBe(1);
+    expect(results.summary.medium).toBe(1);
+    expect(results.summary.low).toBe(0);
+    expect(results.summary.total).toBe(2);
+  });
+});
+
+describe('buildReminderMessage', () => {
+  const baseAccount = makeAccount({totalPurchased: 15, totalPaid: 0});
+
+  it('builds high tier message with debt amount and threshold', () => {
+    const message = buildReminderMessage({
+      account: baseAccount,
+      debt: 15,
+      tier: 'high',
+    });
+
+    expect(message).toContain('15.00€');
+    expect(message).toContain('10€ threshold');
+    expect(message).toContain(':chaquip-cat:');
+  });
+
+  it('builds medium tier message mentioning inactivity', () => {
+    const message = buildReminderMessage({
+      account: baseAccount,
+      debt: 7.5,
+      tier: 'medium',
+    });
+
+    expect(message).toContain('7.50€');
+    expect(message).toContain('30 days');
+    expect(message).toContain(':chaquip-cat:');
+  });
+
+  it('builds low tier message mentioning long absence', () => {
+    const message = buildReminderMessage({
+      account: baseAccount,
+      debt: 3,
+      tier: 'low',
+    });
+
+    expect(message).toContain('3.00€');
+    expect(message).toContain('6 months');
+    expect(message).toContain(':chaquip-cat:');
+  });
+});

--- a/src/components/DebtRemindersModal.tsx
+++ b/src/components/DebtRemindersModal.tsx
@@ -33,6 +33,18 @@ const TIER_COLORS: Record<string, string> = {
   low: 'yellow',
 };
 
+const formatLastSeen = (timestamp: number): string => {
+  if (timestamp === 0) return 'Never';
+  const now = Date.now();
+  const days = Math.floor((now - timestamp) / (24 * 60 * 60 * 1000));
+  if (days === 0) return 'Today';
+  if (days === 1) return '1 day ago';
+  if (days < 30) return `${String(days)} days ago`;
+  const months = Math.floor(days / 30);
+  if (months === 1) return '1 month ago';
+  return `${String(months)} months ago`;
+};
+
 export const DebtRemindersModal = ({
   isOpen,
   onClose,
@@ -93,20 +105,28 @@ export const DebtRemindersModal = ({
                     <Th>Name</Th>
                     <Th>Tier</Th>
                     <Th isNumeric>Debt</Th>
+                    <Th>Last Seen</Th>
                   </Tr>
                 </Thead>
                 <Tbody>
-                  {results.details.map((entry) => (
-                    <Tr key={entry.slackId}>
-                      <Td>{entry.name}</Td>
-                      <Td>
-                        <Badge colorScheme={TIER_COLORS[entry.tier]}>
-                          {entry.tier}
-                        </Badge>
-                      </Td>
-                      <Td isNumeric>{entry.debt.toFixed(2)}€</Td>
-                    </Tr>
-                  ))}
+                  {[...results.details]
+                    .sort((a, b) => b.debt - a.debt)
+                    .map((entry) => (
+                      <Tr key={entry.slackId}>
+                        <Td>{entry.name}</Td>
+                        <Td>
+                          <Badge colorScheme={TIER_COLORS[entry.tier]}>
+                            {entry.tier}
+                          </Badge>
+                        </Td>
+                        <Td isNumeric>{entry.debt.toFixed(2)}€</Td>
+                        <Td>
+                          <Text fontSize={'sm'} color={'gray.600'}>
+                            {formatLastSeen(entry.lastPurchaseTimestamp)}
+                          </Text>
+                        </Td>
+                      </Tr>
+                    ))}
                 </Tbody>
               </Table>
             ) : (

--- a/src/components/DebtRemindersModal.tsx
+++ b/src/components/DebtRemindersModal.tsx
@@ -1,0 +1,126 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Button,
+  VStack,
+  HStack,
+  Badge,
+  Text,
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+} from '@chakra-ui/react';
+import type {DebtRemindersResults} from '../types/debtRemindersResults';
+
+type DebtRemindersModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  results: DebtRemindersResults | null;
+};
+
+const TIER_COLORS: Record<string, string> = {
+  high: 'red',
+  medium: 'orange',
+  low: 'yellow',
+};
+
+export const DebtRemindersModal = ({
+  isOpen,
+  onClose,
+  results,
+}: DebtRemindersModalProps) => {
+  if (!results) return null;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size={'xl'}
+      scrollBehavior={'inside'}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <VStack align={'start'} spacing={1}>
+            <Text>Debt Reminders — Dry Run</Text>
+            <Text fontSize={'sm'} fontWeight={'normal'} color={'gray.600'}>
+              {new Date(results.executedAt).toLocaleString()}
+            </Text>
+          </VStack>
+        </ModalHeader>
+        <ModalCloseButton />
+
+        <ModalBody>
+          <VStack spacing={6} align={'stretch'}>
+            <Box>
+              <Text
+                fontSize={'sm'}
+                fontWeight={'semibold'}
+                mb={3}
+                color={'gray.700'}
+              >
+                Summary
+              </Text>
+              <HStack spacing={3} wrap={'wrap'}>
+                <Badge colorScheme={'red'} fontSize={'md'} px={3} py={1}>
+                  {results.summary.high} High (&gt;10€)
+                </Badge>
+                <Badge colorScheme={'orange'} fontSize={'md'} px={3} py={1}>
+                  {results.summary.medium} Medium (5-10€)
+                </Badge>
+                <Badge colorScheme={'yellow'} fontSize={'md'} px={3} py={1}>
+                  {results.summary.low} Low (&lt;5€)
+                </Badge>
+                <Badge colorScheme={'gray'} fontSize={'md'} px={3} py={1}>
+                  {results.summary.total} Total
+                </Badge>
+              </HStack>
+            </Box>
+
+            {results.details.length > 0 ? (
+              <Table size={'sm'}>
+                <Thead>
+                  <Tr>
+                    <Th>Name</Th>
+                    <Th>Tier</Th>
+                    <Th isNumeric>Debt</Th>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {results.details.map((entry) => (
+                    <Tr key={entry.slackId}>
+                      <Td>{entry.name}</Td>
+                      <Td>
+                        <Badge colorScheme={TIER_COLORS[entry.tier]}>
+                          {entry.tier}
+                        </Badge>
+                      </Td>
+                      <Td isNumeric>{entry.debt.toFixed(2)}€</Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+            ) : (
+              <Box textAlign={'center'} py={4}>
+                <Text color={'gray.600'}>No one to remind</Text>
+              </Box>
+            )}
+          </VStack>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button onClick={onClose}>Close</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/src/components/DebtRemindersModal.unit.test.tsx
+++ b/src/components/DebtRemindersModal.unit.test.tsx
@@ -1,0 +1,92 @@
+import {describe, it, expect, vi} from 'vitest';
+import {renderWithChakra} from '../utils/tests';
+import {DebtRemindersModal} from './DebtRemindersModal';
+import type {DebtRemindersResults} from '../types/debtRemindersResults';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const makeResults = (
+  overrides?: Partial<DebtRemindersResults>,
+): DebtRemindersResults => ({
+  summary: {high: 1, medium: 1, low: 0, total: 2, sent: 0, failed: 0},
+  details: [
+    {
+      name: 'Alice',
+      slackId: 'slack-1',
+      debt: 7,
+      tier: 'medium',
+      lastPurchaseTimestamp: Date.now() - 35 * MS_PER_DAY,
+      sent: false,
+    },
+    {
+      name: 'Bob',
+      slackId: 'slack-2',
+      debt: 15,
+      tier: 'high',
+      lastPurchaseTimestamp: Date.now() - 2 * MS_PER_DAY,
+      sent: false,
+    },
+  ],
+  dryRun: true,
+  executedAt: '2026-04-01T12:00:00.000Z',
+  ...overrides,
+});
+
+describe('DebtRemindersModal', () => {
+  it('renders nothing when results is null', () => {
+    const {queryByRole} = renderWithChakra(
+      <DebtRemindersModal isOpen={true} onClose={vi.fn()} results={null} />,
+    );
+
+    expect(queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('displays summary badges', () => {
+    const results = makeResults();
+    const {getByText} = renderWithChakra(
+      <DebtRemindersModal isOpen={true} onClose={vi.fn()} results={results} />,
+    );
+
+    expect(getByText('1 High (>10€)')).toBeInTheDocument();
+    expect(getByText('1 Medium (5-10€)')).toBeInTheDocument();
+    expect(getByText('0 Low (<5€)')).toBeInTheDocument();
+    expect(getByText('2 Total')).toBeInTheDocument();
+  });
+
+  it('displays details sorted by biggest debt first', () => {
+    const results = makeResults();
+    const {getAllByRole} = renderWithChakra(
+      <DebtRemindersModal isOpen={true} onClose={vi.fn()} results={results} />,
+    );
+
+    const rows = getAllByRole('row');
+    const dataRows = rows.slice(1);
+
+    expect(dataRows[0].textContent).toContain('Bob');
+    expect(dataRows[0].textContent).toContain('15.00€');
+    expect(dataRows[1].textContent).toContain('Alice');
+    expect(dataRows[1].textContent).toContain('7.00€');
+  });
+
+  it('shows last seen column', () => {
+    const results = makeResults();
+    const {getByText} = renderWithChakra(
+      <DebtRemindersModal isOpen={true} onClose={vi.fn()} results={results} />,
+    );
+
+    expect(getByText('Last Seen')).toBeInTheDocument();
+    expect(getByText('2 days ago')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no reminders', () => {
+    const results = makeResults({
+      summary: {high: 0, medium: 0, low: 0, total: 0, sent: 0, failed: 0},
+      details: [],
+    });
+    const {getByText} = renderWithChakra(
+      <DebtRemindersModal isOpen={true} onClose={vi.fn()} results={results} />,
+    );
+
+    expect(getByText('No one to remind')).toBeInTheDocument();
+  });
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,3 +5,4 @@ export * from './DrinkCard';
 export * from './TransactionList';
 export * from './SyncResultsModal';
 export * from './GlobalBalanceDisplay';
+export * from './DebtRemindersModal';

--- a/src/pages/AccountGrid.tsx
+++ b/src/pages/AccountGrid.tsx
@@ -20,11 +20,13 @@ import {
   HelpModal,
   SyncResultsModal,
   GlobalBalanceDisplay,
+  DebtRemindersModal,
 } from '../components';
 import {useAccounts, useAuth} from '../hooks';
 import {FocusableElement} from '../models';
 import {FocusableElementRefContext} from '../contexts';
 import type {SyncResults} from '../types/syncResults';
+import type {DebtRemindersResults} from '../types/debtRemindersResults';
 
 type SortOption = 'lastTransaction' | 'debt' | 'totalPaid';
 type EmployeeFilter = 'all' | 'employee' | 'nonEmployee';
@@ -39,8 +41,17 @@ export const AccountGrid = () => {
   const {logOut} = useAuth();
   const toast = useToast();
   const {isOpen, onOpen, onClose} = useDisclosure();
+  const {
+    isOpen: isDebtOpen,
+    onOpen: onDebtOpen,
+    onClose: onDebtClose,
+  } = useDisclosure();
   const [isUpdating, setIsUpdating] = useState(false);
   const [syncResults, setSyncResults] = useState<SyncResults | null>(null);
+  const [isLoadingDebtReminders, setIsLoadingDebtReminders] = useState(false);
+  const [debtResults, setDebtResults] = useState<DebtRemindersResults | null>(
+    null,
+  );
 
   const handleChargeSuccess = useCallback(() => {
     setSearchValue('');
@@ -73,6 +84,34 @@ export const AccountGrid = () => {
       setIsUpdating(false);
     }
   }, [toast, onOpen]);
+
+  const handleDebtRemindersDryRun = useCallback(async () => {
+    setIsLoadingDebtReminders(true);
+    setDebtResults(null);
+
+    try {
+      const functions = getFunctions();
+      const sendDebtRemindersDryRun = httpsCallable<
+        Record<string, never>,
+        DebtRemindersResults
+      >(functions, 'sendDebtRemindersDryRun');
+      const response = await sendDebtRemindersDryRun({});
+      setDebtResults(response.data);
+      onDebtOpen();
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to run debt reminders';
+      toast({
+        title: 'Debt Reminders Failed',
+        description: errorMessage,
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setIsLoadingDebtReminders(false);
+    }
+  }, [toast, onDebtOpen]);
 
   const filteredAccounts = useMemo(() => {
     if (accounts === null) return null;
@@ -310,17 +349,29 @@ export const AccountGrid = () => {
                 />
               )}
             </Box>
-            <Button
-              onClick={() => void handleSyncUsers()}
-              leftIcon={<RepeatIcon />}
-              colorScheme={'blue'}
-              variant={'outline'}
-              size={'sm'}
-              isLoading={isUpdating}
-              loadingText={'Syncing...'}
-            >
-              Sync Users
-            </Button>
+            <HStack spacing={2}>
+              <Button
+                onClick={() => void handleDebtRemindersDryRun()}
+                colorScheme={'orange'}
+                variant={'outline'}
+                size={'sm'}
+                isLoading={isLoadingDebtReminders}
+                loadingText={'Checking...'}
+              >
+                Debt Reminders
+              </Button>
+              <Button
+                onClick={() => void handleSyncUsers()}
+                leftIcon={<RepeatIcon />}
+                colorScheme={'blue'}
+                variant={'outline'}
+                size={'sm'}
+                isLoading={isUpdating}
+                loadingText={'Syncing...'}
+              >
+                Sync Users
+              </Button>
+            </HStack>
           </HStack>
         </Box>
         <Box px={8} py={8}>
@@ -350,6 +401,11 @@ export const AccountGrid = () => {
         isOpen={isOpen}
         onClose={onClose}
         results={syncResults}
+      />
+      <DebtRemindersModal
+        isOpen={isDebtOpen}
+        onClose={onDebtClose}
+        results={debtResults}
       />
     </FocusableElementRefContext.Provider>
   );

--- a/src/types/debtRemindersResults.ts
+++ b/src/types/debtRemindersResults.ts
@@ -1,0 +1,24 @@
+export type ReminderTier = 'high' | 'medium' | 'low';
+
+export type ReminderResult = {
+  name: string;
+  slackId: string;
+  debt: number;
+  tier: ReminderTier;
+  sent: boolean;
+  error?: string;
+};
+
+export type DebtRemindersResults = {
+  summary: {
+    high: number;
+    medium: number;
+    low: number;
+    total: number;
+    sent: number;
+    failed: number;
+  };
+  details: ReminderResult[];
+  dryRun: boolean;
+  executedAt: string;
+};

--- a/src/types/debtRemindersResults.ts
+++ b/src/types/debtRemindersResults.ts
@@ -5,6 +5,7 @@ export type ReminderResult = {
   slackId: string;
   debt: number;
   tier: ReminderTier;
+  lastPurchaseTimestamp: number;
   sent: boolean;
   error?: string;
 };


### PR DESCRIPTION
## Summary
- Add a new Cloud Function `sendDebtRemindersDryRun` that categorizes employees into 3 debt tiers and returns who would be notified
  - **High** (>10€): always reminded
  - **Medium** (5-10€): reminded if no purchase in 30+ days
  - **Low** (≤5€): reminded if no purchase in 6+ months
- Scheduler is not deployed yet — only the dry-run callable is included so we can validate output on prod first
- Shared logic in `debtReminderService.ts` with 19 unit tests

## Test plan
- [x] Unit tests pass (`yarn vitest run functions/src/shared/debtReminderService.unit.test.ts`)
- [x] Lint and TypeScript checks pass
- [ ] Deploy to prod and call `sendDebtRemindersDryRun` to validate categorization
- [ ] Once validated, re-add the scheduler function (`onSchedule` every Tuesday 15:00 Europe/Paris)

🤖 Generated with [Claude Code](https://claude.com/claude-code)